### PR TITLE
Added Upstream to PR Reusable Workflow

### DIFF
--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -1,45 +1,33 @@
+---
 name: Upstream to PR
 
 on:
   workflow_call:
-    inputs: {
-        upstream_repository: {
-            required: true,
-            type: string
-        },
-        upstream_tag_regex: {
-            required: false,
-            type: string
-        },
-        upstream_branch: {
-            required: false,
-            type: string,
-            default: 'main'
-        }
-    }
+    inputs: {upstream_repository: {required: true, type: string}, upstream_tag_regex: {required: false, type: string}, upstream_branch: {required: false,
+        type: string, default: main}}
     secrets:
-        personal_access_token:
-            required: true
+      personal_access_token:
+        required: true
 
 jobs:
   autoupdate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          token: ${{ secrets.personal_access_token }}
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        token: ${{ secrets.personal_access_token }}
 
-      - uses: fopina/upstream-to-pr@v1
-        if: inputs.upstream_tag_regex != null
-        with:
-          token: ${{ secrets.personal_access_token }}
-          upstream-repository: ${{ inputs.upstream_repository }}
-          upstream-tag: ${{ inputs.upstream_tag_regex }}
-      
-      - uses: fopina/upstream-to-pr@v1
-        if: inputs.upstream_tag_regex == null && inputs.upstream_branch != null
-        with:
-          token: ${{ secrets.personal_access_token }}
-          upstream-repository: ${{ inputs.upstream_repository }}
-          upstream-branch: ${{ inputs.upstream_branch }}
+    - uses: fopina/upstream-to-pr@v1
+      if: inputs.upstream_tag_regex != null
+      with:
+        token: ${{ secrets.personal_access_token }}
+        upstream-repository: ${{ inputs.upstream_repository }}
+        upstream-tag: ${{ inputs.upstream_tag_regex }}
+
+    - uses: fopina/upstream-to-pr@v1
+      if: inputs.upstream_tag_regex == null && inputs.upstream_branch != null
+      with:
+        token: ${{ secrets.personal_access_token }}
+        upstream-repository: ${{ inputs.upstream_repository }}
+        upstream-branch: ${{ inputs.upstream_branch }}

--- a/.github/workflows/auto-pr.yaml
+++ b/.github/workflows/auto-pr.yaml
@@ -1,0 +1,45 @@
+name: Upstream to PR
+
+on:
+  workflow_call:
+    inputs: {
+        upstream_repository: {
+            required: true,
+            type: string
+        },
+        upstream_tag_regex: {
+            required: false,
+            type: string
+        },
+        upstream_branch: {
+            required: false,
+            type: string,
+            default: 'main'
+        }
+    }
+    secrets:
+        personal_access_token:
+            required: true
+
+jobs:
+  autoupdate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.personal_access_token }}
+
+      - uses: fopina/upstream-to-pr@v1
+        if: inputs.upstream_tag_regex != null
+        with:
+          token: ${{ secrets.personal_access_token }}
+          upstream-repository: ${{ inputs.upstream_repository }}
+          upstream-tag: ${{ inputs.upstream_tag_regex }}
+      
+      - uses: fopina/upstream-to-pr@v1
+        if: inputs.upstream_tag_regex == null && inputs.upstream_branch != null
+        with:
+          token: ${{ secrets.personal_access_token }}
+          upstream-repository: ${{ inputs.upstream_repository }}
+          upstream-branch: ${{ inputs.upstream_branch }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
   hooks:
   - id: yesqa
 - repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
+  rev: 5.13.2
   hooks:
   - id: isort
 - repo: https://github.com/psf/black


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the process of creating pull requests from upstream changes. The workflow is defined in the `.github/workflows/auto-pr.yaml` file and includes several configurable inputs and steps.

Key changes:

* Added a new GitHub Actions workflow named `Upstream to PR` to automate the creation of pull requests from upstream changes. The workflow can be triggered with specific inputs and uses a personal access token for authentication. (`.github/workflows/auto-pr.yaml`)

* Configured the workflow to accept inputs for the upstream repository, optional tag regex, and optional branch, with a default branch of `main`. (`.github/workflows/auto-pr.yaml`)

* Included steps to check out the repository and use the `fopina/upstream-to-pr@v1` action to create pull requests based on the provided inputs. (`.github/workflows/auto-pr.yaml`)